### PR TITLE
Fix install-binary.sh to work with Helm v3

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -5,7 +5,13 @@
 PROJECT_NAME="helm-unittest"
 PROJECT_GH="lrills/$PROJECT_NAME"
 
-: ${HELM_PLUGIN_PATH:="$(helm home)/plugins/helm-unittest"}
+if helm version | grep -q v3; then
+  HELM_PATH="$(helm env | grep HELM_PLUGINS | awk -F '=' '{print $2}' | sed 's/\"//g')"
+else
+  HELM_PATH="$(helm home)"
+fi
+
+: "${HELM_PLUGIN_PATH:="$HELM_PATH/helm-unittest"}"
 
 # Convert the HELM_PLUGIN_PATH to unix if cygpath is
 # available. This is the case when using MSYS2 or Cygwin
@@ -74,7 +80,7 @@ getDownloadURL() {
   if type "curl" >/dev/null 2>&1; then
     DOWNLOAD_URL=$(curl -s $latest_url | grep $OS | awk '/\"browser_download_url\":/{gsub( /[,\"]/,"", $2); print $2}')
   elif type "wget" >/dev/null 2>&1; then
-    DOWNLOAD_URL=$(wget -q -O - $latest_url | awk '/\"browser_download_url\":/{gsub( /[,\"]/,"", $2); print $2}')
+    DOWNLOAD_URL=$(wget -q -O - $latest_url | grep $OS | awk '/\"browser_download_url\":/{gsub( /[,\"]/,"", $2); print $2}')
   fi
 }
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,5 +5,5 @@ description: "Unit test for helm chart in YAML with ease to keep your chart func
 ignoreFlags: false
 command: "$HELM_PLUGIN_DIR/untt"
 hooks:
-  install: "$HELM_PLUGIN_DIR/install-binary.sh"
-  update: "$HELM_PLUGIN_DIR/install-binary.sh"
+  install: "cd $HELM_PLUGIN_DIR; $HELM_PLUGIN_DIR/install-binary.sh"
+  update: "cd $HELM_PLUGIN_DIR; $HELM_PLUGIN_DIR/install-binary.sh"


### PR DESCRIPTION
In the Helm V3 installation, the home command for helm is not available anymore. Adding a way to detect the helm version and execute the corresponding command to install it.

Also, when wget is used: Install failed on a system without curl, since the wget command used to retrieve latest version doesn't grep for the detected OS, and so returns a URL for every available OS, which subsequently causes wget to fail.